### PR TITLE
Restore About layout and add scoped Final Transmission section

### DIFF
--- a/about.html
+++ b/about.html
@@ -237,6 +237,56 @@
             </ul>
           </article>
         </section>
+
+        <section class="section transmission">
+          <h2>Final Transmission</h2>
+          <div class="transmission-panel">
+            <h3 class="transmission-title">FINAL TRANSMISSION: FROM NOISE TO SIGNAL</h3>
+            <p>Alright.</p>
+            <p>I’ve said what I needed to say. Maybe too much. Maybe not enough. Either way — it’s out now.</p>
+            <p>
+              These essays, documents, and transmissions weren’t just ideas. They were frequencies I’ve carried for
+              years. Pressure points. Loops. Glitches in the signal.
+            </p>
+            <p>And now?</p>
+            <p>They’re released.<br />Named. Aired. Grounded.</p>
+            <p>The signal is clean. The loop is closed.</p>
+            <p>So what now?</p>
+            <p>
+              Now, I build.<br />
+              Not another argument.<br />
+              Not another poetic system breakdown.<br />
+              Not another carefully measured dose of existential clarity.
+            </p>
+            <p>
+              <strong>I build a life.</strong><br />
+              The one I want — not the one I was defaulted into.<br />
+              Because I have the tools. The insight. The pattern literacy. And yeah, the drive to carry it all the way.
+            </p>
+            <p>This isn’t retreat.<br />It’s application.</p>
+            <p>I’m going where it’s quiet enough to think, and real enough to build.</p>
+            <p>
+              If you’ve been here — thank you. If you’ve felt even a single sentence of this resonate in your spine, you
+              already know:
+            </p>
+            <p>This was never about being clever.</p>
+            <p>It was about naming the system, stepping off the road, and choosing to walk under your own momentum.</p>
+            <p>And if I <em>do</em> return?</p>
+            <p>
+              It won’t be because I ran out of things to say.<br />
+              It’ll be because I found new ways to say them —<br />
+              or because I finally built the starship I keep joking about.
+            </p>
+            <p>
+              Either way, I’ve got to go now.<br />
+              Time to do the hard work.<br />
+              The good work.<br />
+              The real work.
+            </p>
+            <p class="transmission-signoff">Catch you on the other side.</p>
+            <p class="transmission-footer">— Me</p>
+          </div>
+        </section>
       </div>
     </main>
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -219,6 +219,45 @@ textarea:focus-visible {
   font-size: clamp(1.6rem, 3vw, 2.2rem);
 }
 
+.transmission .transmission-panel {
+  margin: 0 auto;
+  max-width: 800px;
+  padding: clamp(1.5rem, 3vw, 2rem);
+  border-radius: 16px;
+  border: 1px solid #19d719;
+  background: #000;
+  color: #00ff6a;
+  font-family: "Courier New", Courier, monospace;
+  box-shadow: 0 0 24px rgba(0, 255, 106, 0.45);
+  font-size: clamp(1rem, 2.2vw, 1.1rem);
+  line-height: 1.6;
+}
+
+.transmission .transmission-title {
+  margin-top: 0;
+  margin-bottom: var(--space-4);
+  text-align: center;
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  text-shadow: 0 0 8px rgba(0, 255, 106, 0.7);
+}
+
+.transmission .transmission-panel p {
+  margin-top: 0;
+  margin-bottom: var(--space-3);
+}
+
+.transmission .transmission-signoff {
+  text-shadow: 0 0 8px rgba(0, 255, 106, 0.7);
+  margin-bottom: var(--space-2);
+}
+
+.transmission .transmission-footer {
+  margin-bottom: 0;
+  text-align: center;
+  color: rgba(0, 255, 106, 0.65);
+  font-size: 0.95em;
+}
+
 .card-grid {
   display: grid;
   gap: var(--space-4);


### PR DESCRIPTION
### Motivation
- Fix a broken About page that had been replaced with a standalone “Final Transmission” document which removed site integration points and global styles. 
- Preserve the new “Final Transmission” content while preventing it from breaking site-wide layout, navigation, and routing. 
- Scope the sci‑fi terminal styling so it does not clash with existing components or global CSS rules.

### Description
- Restored the original About structure (skip link, `#site-header`, `main` container, `#site-footer`, and the global stylesheet/script) in `about.html` so the page integrates with the site layout. 
- Reinserted the Final Transmission content as a dedicated section wrapped with `class="transmission"` and `.transmission-panel` so the block is isolated from other page elements in `about.html`. 
- Added scoped terminal-style rules to `assets/css/style.css` under the `.transmission` selector (fonts, colors, glow, max-width, spacing) so the effect is local to the transmission section only. 
- Modified files: `about.html` and `assets/css/style.css` (2 files changed); commit message: `Restore About layout with transmission section`.

### Testing
- Launched a local static server using `python -m http.server 8000` and verified the page served successfully. 
- Captured a full-page screenshot via a Playwright script and saved it as `artifacts/about-transmission.png`, confirming the transmission panel renders as scoped and styled. 
- Performed a `git commit` which completed successfully, indicating the changes were staged and recorded without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696498570d14832b83f68356529a2c2f)