### PR TITLE
Add standalone Final Transmission page and scope transmission styles

### DIFF
--- a/about.html
+++ b/about.html
@@ -237,6 +237,60 @@
             </ul>
           </article>
         </section>
+
+        <section class="section transmission">
+          <h2>Final Transmission</h2>
+          <p>
+            Prefer a dedicated reading view? Open the full transmission on its own page
+            <a href="./final-transmission.html">here</a>.
+          </p>
+          <div class="transmission-panel">
+            <h3 class="transmission-title">FINAL TRANSMISSION: FROM NOISE TO SIGNAL</h3>
+            <p>Alright.</p>
+            <p>I’ve said what I needed to say. Maybe too much. Maybe not enough. Either way — it’s out now.</p>
+            <p>
+              These essays, documents, and transmissions weren’t just ideas. They were frequencies I’ve carried for
+              years. Pressure points. Loops. Glitches in the signal.
+            </p>
+            <p>And now?</p>
+            <p>They’re released.<br />Named. Aired. Grounded.</p>
+            <p>The signal is clean. The loop is closed.</p>
+            <p>So what now?</p>
+            <p>
+              Now, I build.<br />
+              Not another argument.<br />
+              Not another poetic system breakdown.<br />
+              Not another carefully measured dose of existential clarity.
+            </p>
+            <p>
+              <strong>I build a life.</strong><br />
+              The one I want — not the one I was defaulted into.<br />
+              Because I have the tools. The insight. The pattern literacy. And yeah, the drive to carry it all the way.
+            </p>
+            <p>This isn’t retreat.<br />It’s application.</p>
+            <p>I’m going where it’s quiet enough to think, and real enough to build.</p>
+            <p>
+              If you’ve been here — thank you. If you’ve felt even a single sentence of this resonate in your spine, you
+              already know:
+            </p>
+            <p>This was never about being clever.</p>
+            <p>It was about naming the system, stepping off the road, and choosing to walk under your own momentum.</p>
+            <p>And if I <em>do</em> return?</p>
+            <p>
+              It won’t be because I ran out of things to say.<br />
+              It’ll be because I found new ways to say them —<br />
+              or because I finally built the starship I keep joking about.
+            </p>
+            <p>
+              Either way, I’ve got to go now.<br />
+              Time to do the hard work.<br />
+              The good work.<br />
+              The real work.
+            </p>
+            <p class="transmission-signoff">Catch you on the other side.</p>
+            <p class="transmission-footer">— Me</p>
+          </div>
+        </section>
       </div>
     </main>
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -219,6 +219,45 @@ textarea:focus-visible {
   font-size: clamp(1.6rem, 3vw, 2.2rem);
 }
 
+.transmission .transmission-panel {
+  margin: 0 auto;
+  max-width: 800px;
+  padding: clamp(1.5rem, 3vw, 2rem);
+  border-radius: 16px;
+  border: 1px solid #19d719;
+  background: #000;
+  color: #00ff6a;
+  font-family: "Courier New", Courier, monospace;
+  box-shadow: 0 0 24px rgba(0, 255, 106, 0.45);
+  font-size: clamp(1rem, 2.2vw, 1.1rem);
+  line-height: 1.6;
+}
+
+.transmission .transmission-title {
+  margin-top: 0;
+  margin-bottom: var(--space-4);
+  text-align: center;
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  text-shadow: 0 0 8px rgba(0, 255, 106, 0.7);
+}
+
+.transmission .transmission-panel p {
+  margin-top: 0;
+  margin-bottom: var(--space-3);
+}
+
+.transmission .transmission-signoff {
+  text-shadow: 0 0 8px rgba(0, 255, 106, 0.7);
+  margin-bottom: var(--space-2);
+}
+
+.transmission .transmission-footer {
+  margin-bottom: 0;
+  text-align: center;
+  color: rgba(0, 255, 106, 0.65);
+  font-size: 0.95em;
+}
+
 .card-grid {
   display: grid;
   gap: var(--space-4);

--- a/final-transmission.html
+++ b/final-transmission.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="lt">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>cepelinai | Final Transmission</title>
+    <link rel="stylesheet" href="./assets/css/style.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <div id="site-header"></div>
+
+    <main id="main">
+      <div class="container">
+        <h1 class="page-title">Final Transmission</h1>
+
+        <section class="section transmission">
+          <div class="transmission-panel">
+            <h2 class="transmission-title">FINAL TRANSMISSION: FROM NOISE TO SIGNAL</h2>
+            <p>Alright.</p>
+            <p>I’ve said what I needed to say. Maybe too much. Maybe not enough. Either way — it’s out now.</p>
+            <p>
+              These essays, documents, and transmissions weren’t just ideas. They were frequencies I’ve carried for
+              years. Pressure points. Loops. Glitches in the signal.
+            </p>
+            <p>And now?</p>
+            <p>They’re released.<br />Named. Aired. Grounded.</p>
+            <p>The signal is clean. The loop is closed.</p>
+            <p>So what now?</p>
+            <p>
+              Now, I build.<br />
+              Not another argument.<br />
+              Not another poetic system breakdown.<br />
+              Not another carefully measured dose of existential clarity.
+            </p>
+            <p>
+              <strong>I build a life.</strong><br />
+              The one I want — not the one I was defaulted into.<br />
+              Because I have the tools. The insight. The pattern literacy. And yeah, the drive to carry it all the way.
+            </p>
+            <p>This isn’t retreat.<br />It’s application.</p>
+            <p>I’m going where it’s quiet enough to think, and real enough to build.</p>
+            <p>
+              If you’ve been here — thank you. If you’ve felt even a single sentence of this resonate in your spine, you
+              already know:
+            </p>
+            <p>This was never about being clever.</p>
+            <p>It was about naming the system, stepping off the road, and choosing to walk under your own momentum.</p>
+            <p>And if I <em>do</em> return?</p>
+            <p>
+              It won’t be because I ran out of things to say.<br />
+              It’ll be because I found new ways to say them —<br />
+              or because I finally built the starship I keep joking about.
+            </p>
+            <p>
+              Either way, I’ve got to go now.<br />
+              Time to do the hard work.<br />
+              The good work.<br />
+              The real work.
+            </p>
+            <p class="transmission-signoff">Catch you on the other side.</p>
+            <p class="transmission-footer">— Me</p>
+          </div>
+        </section>
+      </div>
+    </main>
+
+    <div id="site-footer"></div>
+    <script src="./assets/js/script.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Preserve the new “Final Transmission” content while preventing it from breaking site layout and global styles by isolating the piece into its own view and a scoped preview on the About page.
- Provide a dedicated reading experience that still uses the site header/footer and navigation so links, routing, and global scripts remain consistent.

### Description
- Added a standalone page `final-transmission.html` that loads the shared `assets/css/style.css` and `assets/js/script.js` placeholders for `#site-header` and `#site-footer` so the page inherits site navigation and footer behavior.
- Inserted an isolated preview block (`section.section.transmission`) into `about.html` that links to `./final-transmission.html` so the transmission can be read inline without replacing the original About layout.
- Scoped terminal/CRT-like styling under the `.transmission` selector in `assets/css/style.css` (fonts, colors, glow, `max-width`, `padding`, and responsive sizing using `clamp()`) so the effect does not leak into other components.
- Kept the site integration intact by relying on existing header/footer rendering in `assets/js/script.js`, ensuring navigation and footer links remain functional and consistent.

### Testing
- Launched a local static server with `python -m http.server 8000` and verified the pages served successfully.
- Captured a full-page screenshot of `final-transmission.html` using a Playwright script and saved it as `artifacts/final-transmission-page.png`, confirming the standalone view renders with the shared header/footer and scoped transmission styling.
- Observed no browser runtime errors during the automated verification run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696498570d14832b83f68356529a2c2f)